### PR TITLE
Fix fread exception when length < 1

### DIFF
--- a/lib/IP2Location.php
+++ b/lib/IP2Location.php
@@ -1589,6 +1589,10 @@ class Database
 	 */
 	private function read($pos, $len)
 	{
+    if ($len < 1) {
+			return '';
+		}
+
 		switch ($this->mode) {
 		case self::SHARED_MEMORY:
 		return shmop_read($this->resource, $pos, $len);


### PR DESCRIPTION
Fixes this exception:
> Uncaught exception in plugins/IP2Location/lib/IP2Location.php line 1602:
> fread(): Argument #2 ($length) must be greater than 0

I think the exception was thrown when processing a IPv6 address, but I am not 100% certain