### PR TITLE
Fixed the remaining instances of `path.ip2location` that the 4.1.1 release left behind.

### DIFF
--- a/API.php
+++ b/API.php
@@ -44,24 +44,24 @@ class API extends \Piwik\Plugin\API
 
 	public static function getDatabaseDate($file)
 	{
-		if (!is_file(StaticContainer::get('path.ip2location') . $file)) {
+		if (!is_file(PIWIK_DOCUMENT_ROOT . '/misc/' . $file)) {
 			return;
 		}
 
 		require_once PIWIK_INCLUDE_PATH . '/plugins/IP2Location/lib/IP2Location.php';
 
-		$db = new \IP2Location\Database(StaticContainer::get('path.ip2location') . $file, \IP2Location\Database::FILE_IO);
+		$db = new \IP2Location\Database(PIWIK_DOCUMENT_ROOT . '/misc/' . $file, \IP2Location\Database::FILE_IO);
 
 		return $db->getDate();
 	}
 
 	public static function getDatabaseSize($file)
 	{
-		if (!file_exists(StaticContainer::get('path.ip2location') . $file)) {
+		if (!file_exists(PIWIK_DOCUMENT_ROOT . '/misc/' . $file)) {
 			return 0;
 		}
 
-		return self::displayBytes(filesize(StaticContainer::get('path.ip2location') . $file));
+		return self::displayBytes(filesize(PIWIK_DOCUMENT_ROOT . '/misc/' . $file));
 	}
 
 	public static function getLookupMode()


### PR DESCRIPTION
Version 4.1.1 of this plugin was released to fix an error introduced by the `StaticContainer::get('path.ip2location')` being used instead of the `PIWIK_DOCUMENT_ROOT . '/misc/'` that was otherwise used until version 4.1.0 (then causing issues in 4.1.0 with that updated code trying to pull `path.ip2location`). However, 4.1.1 only fixed the first instance of this & left behind all other instances that are also potentially causing issues (per https://github.com/ip2location/ip2location-piwik/commit/d707ddc6afe7c3c43080d2edf9f653db2a619b2b).

As such, this makes it so the fix from 4.1.1 is applied to all other spots where it's potentially needed (just fixing that one spot like what 4.1.1 did wasn't sufficient for my setup, but this update has it back to working normally by simply applying that same fix to more than one spot.)

Of course, I've also mentioned this as an issue here: https://github.com/ip2location/ip2location-piwik/issues/76